### PR TITLE
Fix a bug in TESAN-forward when compute_loss=False

### DIFF
--- a/model_tesan.py
+++ b/model_tesan.py
@@ -185,7 +185,10 @@ class TESAN(nn.Module):
 
     def forward(self, input, word_vecs, mask, compute_loss=False, avg_loss=True):
         # NTM
-        recon, ntm_loss, dt_vec = self.ntm(input, compute_loss, avg_loss)
+        if compute_loss:
+            recon, ntm_loss, dt_vec = self.ntm(input, compute_loss, avg_loss)
+        else:
+            recon, dt_vec = self.ntm(input, compute_loss, avg_loss)
 
         # topic-enhanced self-attention
         doc_vec = self.tesa(word_vecs, dt_vec, mask)


### PR DESCRIPTION
### Issue Description

When `compute_loss=False` is passed to the TESAN's `forward` function, it triggers a bug:

```
recon, ntm_loss, dt_vec = self.ntm(input, compute_loss, avg_loss)
ValueError: not enough values to unpack (expected 3, got 2)
```

This error occurs because the NTM's `forward` function returns only 2 values instead of the expected 3 when `compute_loss` is set to `False`.

### Fix

Add a if sentence